### PR TITLE
Issues #7 Fix

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,8 +51,8 @@ export function activate(context: vscode.ExtensionContext) {
                 return;
             }
             
-            var inFile = path.join(filePath, fileName).replace(/ /g, '\\ ');
-            var outFile = path.join(filePath, fileNameOnly).replace(/ /g, '\\ ') + '.' + qpSelection.label;            
+            var inFile = path.join(filePath, fileName).replace(/(^.*$)/gm,"\"" + "$1" + "\"");
+            var outFile = (path.join(filePath, fileNameOnly) + '.' + qpSelection.label).replace(/(^.*$)/gm,"\"" + "$1" + "\"");
             
             setStatusBarText('Generating', qpSelection.label);
             


### PR DESCRIPTION
Enclose the path in double quotes.

Windows: 
```
debug: inFile = "c:\Users\kazus\Desktop\新しいフォルダー\test 2.md"
debug: outFile = "c:\Users\kazus\Desktop\新しいフォルダー\test 2.html"
```

Mac OS X:
```
debug: outFile = "/Users/satokaz/test 2.md"
debug: inFile = "/Users/satokaz/test 2.pdf"
```