### PR TITLE
Add the location information for the execution of child process

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,7 +67,7 @@ export function activate(context: vscode.ExtensionContext) {
             var targetExec = 'pandoc' + space + inFile + space + '-o' + space + outFile + space + pandocOptions;
             console.log('debug: exec ' + targetExec);
             
-            var child = exec(targetExec, function(error, stdout, stderr) {
+            var child = exec(targetExec, { cwd: filePath }, function(error, stdout, stderr) {
                                 
                 if (stdout !== null) {
                     console.log(stdout.toString());


### PR DESCRIPTION
When pandoc executes as the child process, the execution location is obscure. So, PDF generation fails in my environment. this error log shown in the console of the developer tool is as follows:

<pre>[Plugin Host] exec error: Error: Command failed: C:\WINDOWS\system32\cmd.exe /s /c
"pandoc "c:\Users\hata\Documents\sample.md" -o "c:\Users\hata\Documents\sample.pdf"
--latex-engine=xelatex -V documentclass=bxjsarticle -V geometry:a4paper -V classoption:pandoc -V classoption:jafont=yu-win"
pandoc: CreateDirectory ".\\tex2pdf.7496": permission denied</pre>

Probably, the child process of pandoc executes in a system directory.
For this reason, I modified the code for to specify the execution path of the child process and PDF generation succeeded.