### PR TITLE
Possibility to set custom path for the pandoc executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ example:
 "pandoc.docxOptString": "",
 
 // pandoc .html output option template that you would like to use
-"pandoc.htmlOptString": ""
+"pandoc.htmlOptString": "",
+
+// path to the pandoc executable. By default gets from PATH variable
+"pandoc.executable": ""
 ```
 
 * if necessary to set options for each output format.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # vscode-pandoc
 
-The vscode-pandoc [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=DougFinke.vscode-pandoc) extension lets you quickly render markdown files as a `pdf`, `word document` or `html` file.
+The vscode-pandoc [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=chrischinchilla.vscode-pandoc) extension lets you quickly render markdown files as a `pdf`, `word document` or `html` file.
+
+_Thanks to the previous work of [@dfinke](https://github.com/dfinke) on this extension._
 
 ## Prerequisites
 
@@ -21,14 +23,15 @@ Then choose from the list what document type you want to render and press `enter
 
 ## Releases
 
+* April 22nd, 2020
+  * Shift to new fork
+  * Expose further conversion options
 * July 9, 2016
   * Update package.json and launch.json
   * Add PR #11
   * Add output of the error (use OutputChannel and showErrorMessage)
-
 * January 17, 2016
   * Set pandoc options for document types
-
 * January 16, 2016
   * Handling of the path that contains spaces
   * Add the open command (xdg-open) in linux

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "vscode-pandoc",
 	"description": "Renders markdown through pandoc",
-	"version": "0.0.8",
+	"version": "0.1.0",
 	"publisher": "ChrisChinchilla",
 	"icon": "images/logo.png",
 	"license": "SEE LICENSE",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "vscode-pandoc",
 	"description": "Renders markdown through pandoc",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"publisher": "ChrisChinchilla",
 	"icon": "images/logo.png",
 	"license": "SEE LICENSE",

--- a/package.json
+++ b/package.json
@@ -2,17 +2,17 @@
 	"name": "vscode-pandoc",
 	"description": "Renders markdown through pandoc",
 	"version": "0.0.8",
-	"publisher": "DougFinke",
+	"publisher": "ChrisChinchilla",
 	"icon": "images/logo.png",
 	"license": "SEE LICENSE",
 	"bugs": {
-		"url": "https://github.com/dfinke/vscode-pandoc/issues",
-		"email": "finked@hotmail.com"
+		"url": "https://github.com/chrischinchilla/vscode-pandoc/issues",
+		"email": "chris@chrischinchilla.com"
 	},
-	"homepage": "https://github.com/dfinke/vscode-pandoc/blob/master/README.md",
+	"homepage": "https://github.com/chrischinchilla/vscode-pandoc/blob/master/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/dfinke/vscode-pandoc.git"
+		"url": "https://github.com/chrischinchilla/vscode-pandoc.git"
 	},
 	"engines": {
 		"vscode": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,12 @@
             "type": "string",
             "default": "",
             "description": "pandoc .html output option template that you would like to use"
-          }
+					},
+					"pandoc.executable": {
+							"type": "string",
+							"default": "",
+							"description": "pandoc executable location if not specified in the PATH variable"
+					}
        }
      },
      "keybindings": [

--- a/package.json
+++ b/package.json
@@ -2,12 +2,9 @@
 	"name": "vscode-pandoc",
 	"description": "Renders markdown through pandoc",
 	"version": "0.0.8",
-
 	"publisher": "DougFinke",
 	"icon": "images/logo.png",
-
 	"license": "SEE LICENSE",
-
 	"bugs": {
 		"url": "https://github.com/dfinke/vscode-pandoc/issues",
 		"email": "finked@hotmail.com"
@@ -17,7 +14,6 @@
 		"type": "git",
 		"url": "https://github.com/dfinke/vscode-pandoc.git"
 	},
-
 	"engines": {
 		"vscode": "^1.0.0"
 	},
@@ -25,51 +21,78 @@
 		"Other"
 	],
 	"activationEvents": [
-         "onLanguage:markdown"
+		"onLanguage:markdown",
+		"onLanguage:asciidoc",
+		"onLanguage:xml",
+		"onLanguage:html",
+		"onLanguage:epub",
+		"onLanguage:restructuredtext"
 	],
 	"main": "./out/src/extension",
 	"contributes": {
-     "configuration": {
-       "type": "object",
-       "title": "Pandoc Option Configuration",
-       "properties": {
-         "pandoc.pdfOptString": {
-           "type": "string",
-           "default": "",
-           "description": "pandoc .pdf output option template that you would like to use"
-          },
-          "pandoc.docxOptString": {
-            "type": "string",
-            "default": "",
-            "description": "pandoc .docx output option template that you would like to use"
-          },
-          "pandoc.htmlOptString": {
-            "type": "string",
-            "default": "",
-            "description": "pandoc .html output option template that you would like to use"
-          }
-       }
-     },
-     "keybindings": [
-       {
-         "command": "pandoc.render",
-         "key": "ctrl+K P",
-         "mac": "cmd+K P",
-         "when": "editorTextFocus && editorLangId == 'markdown'"
-       }
-     ],
-     "commands": [{
-			"command": "pandoc.render",
-			"title": "Pandoc Render"
-		}]
+		"configuration": {
+			"type": "object",
+			"title": "Pandoc Option Configuration",
+			"properties": {
+				"pandoc.pdfOptString": {
+					"type": "string",
+					"default": "",
+					"description": "pandoc .pdf output option template that you would like to use"
+				},
+				"pandoc.docxOptString": {
+					"type": "string",
+					"default": "",
+					"description": "pandoc .docx output option template that you would like to use"
+				},
+				"pandoc.htmlOptString": {
+					"type": "string",
+					"default": "",
+					"description": "pandoc .html output option template that you would like to use"
+				},
+				"pandoc.asciidocOptString": {
+					"type": "string",
+					"default": "",
+					"description": "pandoc .asciidoc output option template that you would like to use"
+				},
+				"pandoc.docbookOptString": {
+					"type": "string",
+					"default": "",
+					"description": "pandoc .xml output option template that you would like to use"
+				},
+				"pandoc.epubOptString": {
+					"type": "string",
+					"default": "",
+					"description": "pandoc .epub output option template that you would like to use"
+				},
+				"pandoc.rstOptString": {
+					"type": "string",
+					"default": "",
+					"description": "pandoc .rst output option template that you would like to use"
+				}
+			}
+		},
+		"keybindings": [
+			{
+				"command": "pandoc.render",
+				"key": "ctrl+K P",
+				"mac": "cmd+K P",
+				"when": "editorTextFocus && editorLangId == 'markdown'"
+			}
+		],
+		"commands": [
+			{
+				"command": "pandoc.render",
+				"title": "Pandoc Render"
+			}
+		]
 	},
 	"scripts": {
 		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
 		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
 		"postinstall": "node ./node_modules/vscode/bin/install"
-},
+	},
 	"devDependencies": {
-        "typescript": "^1.8.5",
-        "vscode": "^0.11.0"
+		"typescript": "^1.8.5",
+		"vscode": "^0.11.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,11 @@
 					"type": "string",
 					"default": "",
 					"description": "pandoc .rst output option template that you would like to use"
+				},
+				"pandoc.render.openViewer": {
+					"type":"boolean",
+					"default": "true",
+					"description": "specify if the extension will open the rendered document in it's default viewer"
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "vscode-pandoc",
 	"description": "Renders markdown through pandoc",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"publisher": "ChrisChinchilla",
 	"icon": "images/logo.png",
 	"license": "SEE LICENSE",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,6 +47,19 @@ function getPandocOptions(quickPickLabel) {
     return pandocOptions;
 }
 
+function openDocument(outFile: string) {
+    switch (process.platform) {
+        case 'darwin':
+            exec('open ' + outFile);
+            break;
+        case 'linux':
+            exec('xdg-open ' + outFile);
+            break;
+        default:
+            exec(outFile);
+    }
+}
+
 export function activate(context: vscode.ExtensionContext) {
 
     console.log('Congratulations, your extension "vscode-pandoc" is now active!');
@@ -108,17 +121,13 @@ export function activate(context: vscode.ExtensionContext) {
                     vscode.window.showErrorMessage('exec error: ' + error);
                     pandocOutputChannel.append('exec error: ' + error + '\n');
                 } else {
-                    setStatusBarText('Launching', qpSelection.label);
-                    switch (process.platform) {
-                        case 'darwin':
-                            exec('open ' + outFile);
-                            break;
-                        case 'linux':
-                            exec('xdg-open ' + outFile);
-                            break;
-                        default:
-                            exec(outFile);
+                    var openViewer = vscode.workspace.getConfiguration('pandoc').get('render.openViewer');
+
+                    if (openViewer) {
+                        setStatusBarText('Launching', qpSelection.label);
+                        openDocument(outFile);
                     }
+
                 }
             });
         });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,18 +1,18 @@
-import * as vscode from 'vscode'; 
-import {spawn, exec} from 'child_process';
+import * as vscode from 'vscode';
+import { spawn, exec } from 'child_process';
 import * as path from 'path';
 
 var pandocOutputChannel = vscode.window.createOutputChannel('Pandoc');
 
-function setStatusBarText(what, docType){
-    var date=new Date();
-    var text=what + ' [' + docType + '] ' + date.toLocaleTimeString();
+function setStatusBarText(what, docType) {
+    var date = new Date();
+    var text = what + ' [' + docType + '] ' + date.toLocaleTimeString();
     vscode.window.setStatusBarMessage(text, 1500);
 }
 
 function getPandocOptions(quickPickLabel) {
     var pandocOptions;
-    
+
     switch (quickPickLabel) {
         case 'pdf':
             pandocOptions = vscode.workspace.getConfiguration('pandoc').get('pdfOptString');
@@ -26,83 +26,103 @@ function getPandocOptions(quickPickLabel) {
             pandocOptions = vscode.workspace.getConfiguration('pandoc').get('htmlOptString');
             console.log('pdocOptstring = ' + pandocOptions);
             break;
+        case 'asciidoc':
+            pandocOptions = vscode.workspace.getConfiguration('pandoc').get('asciidocOptString');
+            console.log('pdocOptstring = ' + pandocOptions);
+            break;
+        case 'docbook':
+            pandocOptions = vscode.workspace.getConfiguration('pandoc').get('docbookOptString');
+            console.log('pdocOptstring = ' + pandocOptions);
+            break;
+        case 'epub':
+            pandocOptions = vscode.workspace.getConfiguration('pandoc').get('epubOptString');
+            console.log('pdocOptstring = ' + pandocOptions);
+            break;
+        case 'rst':
+            pandocOptions = vscode.workspace.getConfiguration('pandoc').get('rstOptString');
+            console.log('pdocOptstring = ' + pandocOptions);
+            break;
     }
-    
+
     return pandocOptions;
 }
 
 export function activate(context: vscode.ExtensionContext) {
 
-	console.log('Congratulations, your extension "vscode-pandoc" is now active!'); 
-    
-	var disposable = vscode.commands.registerCommand('pandoc.render', () => {
-        
+    console.log('Congratulations, your extension "vscode-pandoc" is now active!');
+
+    var disposable = vscode.commands.registerCommand('pandoc.render', () => {
+
         var editor = vscode.window.activeTextEditor;
         var fullName = path.normalize(editor.document.fileName);
         var filePath = path.dirname(fullName);
         var fileName = path.basename(fullName);
         var fileNameOnly = path.parse(fileName).name;
-        
+
         let items: vscode.QuickPickItem[] = [];
-        items.push({ label: 'pdf',  description: 'Render as pdf document'  });
+        items.push({ label: 'pdf', description: 'Render as pdf document' });
         items.push({ label: 'docx', description: 'Render as word document' });
         items.push({ label: 'html', description: 'Render as html document' });
+        items.push({ label: 'asciidoc', description: 'Render as asciidoc document' });
+        items.push({ label: 'docbook', description: 'Render as docbook document' });
+        items.push({ label: 'epub', description: 'Render as epub document' });
+        items.push({ label: 'rst', description: 'Render as rst document' });
 
         vscode.window.showQuickPick(items).then((qpSelection) => {
             if (!qpSelection) {
                 return;
             }
-            
-            var inFile = path.join(filePath, fileName).replace(/(^.*$)/gm,"\"" + "$1" + "\"");
-            var outFile = (path.join(filePath, fileNameOnly) + '.' + qpSelection.label).replace(/(^.*$)/gm,"\"" + "$1" + "\"");
-            
+
+            var inFile = path.join(filePath, fileName).replace(/(^.*$)/gm, "\"" + "$1" + "\"");
+            var outFile = (path.join(filePath, fileNameOnly) + '.' + qpSelection.label).replace(/(^.*$)/gm, "\"" + "$1" + "\"");
+
             setStatusBarText('Generating', qpSelection.label);
-            
+
             var pandocOptions = getPandocOptions(qpSelection.label);
-            
+
             // debug
             console.log('debug: outFile = ' + inFile);
             console.log('debug: inFile = ' + outFile);
             console.log('debug: pandoc ' + inFile + ' -o ' + outFile + pandocOptions);
-            
-            var space = '\x20';            
+
+            var space = '\x20';
             var targetExec = 'pandoc' + space + inFile + space + '-o' + space + outFile + space + pandocOptions;
             console.log('debug: exec ' + targetExec);
-            
-            var child = exec(targetExec, { cwd: filePath }, function(error, stdout, stderr) {
+
+            var child = exec(targetExec, { cwd: filePath }, function (error, stdout, stderr) {
                 if (stdout !== null) {
                     console.log(stdout.toString());
                     pandocOutputChannel.append(stdout.toString() + '\n');
                 }
-                
+
                 if (stderr !== null) {
                     console.log(stderr.toString());
                     if (stderr !== "") {
-                    vscode.window.showErrorMessage('stderr: ' + stderr.toString());
-                    pandocOutputChannel.append('stderr: ' + stderr.toString() + '\n');
+                        vscode.window.showErrorMessage('stderr: ' + stderr.toString());
+                        pandocOutputChannel.append('stderr: ' + stderr.toString() + '\n');
                     }
                 }
-                
+
                 if (error !== null) {
                     console.log('exec error: ' + error);
                     vscode.window.showErrorMessage('exec error: ' + error);
                     pandocOutputChannel.append('exec error: ' + error + '\n');
                 } else {
                     setStatusBarText('Launching', qpSelection.label);
-                    switch(process.platform) {
-                      case 'darwin':
-                        exec('open ' + outFile);
-                        break;
-                      case 'linux':
-                        exec('xdg-open ' + outFile);
-                        break;
-                      default:
-                        exec(outFile);
+                    switch (process.platform) {
+                        case 'darwin':
+                            exec('open ' + outFile);
+                            break;
+                        case 'linux':
+                            exec('xdg-open ' + outFile);
+                            break;
+                        default:
+                            exec(outFile);
                     }
                 }
             });
         });
     });
-	
+
     context.subscriptions.push(disposable);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,16 @@ function getPandocOptions(quickPickLabel) {
     return pandocOptions;
 }
 
+function getPandocExecutablePath() {
+    // By default pandoc executable should be in the PATH environment variable.
+    var pandocExecutablePath = 'pandoc';
+    if (vscode.workspace.getConfiguration('pandoc').has('executable') && 
+        vscode.workspace.getConfiguration('pandoc').get('executable') !== '') {
+        pandocExecutablePath = vscode.workspace.getConfiguration('pandoc').get('executable');
+    }
+    return pandocExecutablePath;
+}
+
 export function activate(context: vscode.ExtensionContext) {
 
 	console.log('Congratulations, your extension "vscode-pandoc" is now active!'); 
@@ -65,8 +75,11 @@ export function activate(context: vscode.ExtensionContext) {
             console.log('debug: inFile = ' + outFile);
             console.log('debug: pandoc ' + inFile + ' -o ' + outFile + pandocOptions);
             
-            var space = '\x20';            
-            var targetExec = 'pandoc' + space + inFile + space + '-o' + space + outFile + space + pandocOptions;
+            var space = '\x20';
+            var pandocExecutablePath = getPandocExecutablePath();
+            console.log('debug: pandoc executable path = ' + pandocExecutablePath);
+
+            var targetExec = pandocExecutablePath + space + inFile + space + '-o' + space + outFile + space + pandocOptions;
             console.log('debug: exec ' + targetExec);
             
             var child = exec(targetExec, { cwd: filePath }, function(error, stdout, stderr) {


### PR DESCRIPTION
1. Add `pandoc.executable` option for pandoc executable
2. Add function `getPandocExecutablePath` that checks `pandoc.executable` option
3. Update `README.md` for new option